### PR TITLE
pad as<array..> with 0s in case size is smaller than expected

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <sstream>
 #include <vector>
+#include <cstring>
 
 #include "yaml-cpp/binary.h"
 #include "yaml-cpp/node/impl.h"
@@ -284,12 +285,15 @@ struct convert<std::array<T, N>> {
       rhs[i] = node[i].as<T>();
 #endif
     }
+    for (auto i = node.size(); i < N; i++) {
+        std::memset(&rhs[i], 0, sizeof(T));
+    }
     return true;
   }
 
  private:
   static bool isNodeValid(const Node& node) {
-    return node.IsSequence() && node.size() == N;
+    return node.IsSequence() && node.size() <= N;
   }
 };
 


### PR DESCRIPTION
For std::array<struct, size> parsing, if yaml parser finds less nodes than expected, decoder will pad remaining structs with 0s